### PR TITLE
[Fix] vendor:publish for Laravel 6.x

### DIFF
--- a/src/RepositoryServiceProvider.php
+++ b/src/RepositoryServiceProvider.php
@@ -43,6 +43,6 @@ class RepositoryServiceProvider extends ServiceProvider
      */
     protected function isLumen()
     {
-        return str_contains($this->app->version(), 'Lumen') === true;
+        return Str::contains($this->app->version(), 'Lumen') === true;
     }
 }


### PR DESCRIPTION
str_contains is deprecated in 5.7 and up